### PR TITLE
feat(ai-tools): articles create auto-resolve company_id from folder_id + global flag

### DIFF
--- a/nodes/Hudu/ai-tools/description-builders.ts
+++ b/nodes/Hudu/ai-tools/description-builders.ts
@@ -116,8 +116,25 @@ export function buildCreateDescription(
   requiredFields: string[],
   referenceUtc?: string,
   supportsSearch = true,
+  resource = '',
 ): string {
   const ref = referenceUtc ? dateTimeReferenceSnippet(referenceUtc) : '';
+
+  if (resource === 'articles') {
+    return (
+      ref +
+      'Create a new article in Hudu. ' +
+      'SCOPE — provide ONE of: (a) company_id (numeric, use hudu_companies_get_id_by_name if unknown), ' +
+      '(b) folder_id (company_id auto-resolved internally — no extra call needed), ' +
+      'or (c) global=true for a global article not tied to any company. ' +
+      'folder_id is optional when global=true (places article in a global folder). ' +
+      'global=true takes precedence over any provided company_id. ' +
+      'content accepts HTML or Markdown. ' +
+      'Confirm field values with user before executing when acting autonomously. ' +
+      'On success returns the created article including its numeric id.'
+    );
+  }
+
   const reqList =
     requiredFields.length > 0 ? `Required fields: ${requiredFields.join(', ')}. ` : '';
   const idFields = requiredFields.filter((f) => f.endsWith('_id') && f !== 'id');
@@ -214,7 +231,7 @@ export function buildUnifiedDescription(
       case 'getAll':
         return `- getAll: ${buildGetAllDescription(resourceLabel, undefined, supportsSearch, resource)}`;
       case 'create':
-        return `- create: ${buildCreateDescription(resourceLabel, requiredFields, undefined, supportsSearch)}`;
+        return `- create: ${buildCreateDescription(resourceLabel, requiredFields, undefined, supportsSearch, resource)}`;
       case 'update':
         return `- update: ${buildUpdateDescription(resourceLabel, resource, supportsSearch)}`;
       case 'delete':

--- a/nodes/Hudu/ai-tools/schema-generator.ts
+++ b/nodes/Hudu/ai-tools/schema-generator.ts
@@ -571,8 +571,31 @@ export function getArticlesCreateSchema() {
   return z.object({
     name: nameSchema.describe('Article title'),
     content: z.string().optional().describe('Article content (HTML or Markdown)'),
-    company_id: optionalCompanyIdSchema,
-    folder_id: z.number().int().positive().optional().describe('Folder ID to place the article in'),
+    global: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'Set true to create a global (non-company) article accessible across all companies. ' +
+        'When false (default), company_id or folder_id is required. ' +
+        'This field is not sent to Hudu — it only controls how the executor resolves company context. ' +
+        'global=true takes precedence over any provided company_id.',
+      ),
+    company_id: optionalCompanyIdSchema.describe(
+      'Numeric company ID. Omit if folder_id is provided — auto-resolved from folder. ' +
+      'If unknown, call hudu_companies_get_id_by_name to resolve company name to ID. ' +
+      'Ignored when global=true.',
+    ),
+    folder_id: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Folder ID to place the article in. ' +
+        'If provided without company_id, company_id is auto-resolved from the folder record (one internal API call). ' +
+        'Always sent to Hudu regardless of how company_id was resolved.',
+      ),
     enable_sharing: z.boolean().optional().describe('Whether to enable public sharing'),
   });
 }

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -121,12 +121,16 @@ async function resolveArticleCreateContext(
   const folderId = params.folder_id;
 
   // Strip client-only field — never reaches Hudu API
-  const { global: _global, ...rest } = params;
+  const rest = Object.fromEntries(
+    Object.entries(params).filter(([k]) => k !== 'global'),
+  ) as Record<string, unknown>;
   let resolved = rest;
 
   // global=true wins; strip company_id too
   if (isGlobal) {
-    const { company_id: _cid, ...withoutCompany } = resolved;
+    const withoutCompany = Object.fromEntries(
+      Object.entries(resolved).filter(([k]) => k !== 'company_id'),
+    ) as Record<string, unknown>;
     return { resolvedParams: withoutCompany };
   }
 

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -154,18 +154,15 @@ async function resolveArticleCreateContext(
       }
       // folder.company_id === null → global folder, proceed without company_id
       return { resolvedParams: resolved };
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       return {
         resolvedParams: resolved,
-        errorJson: JSON.stringify(
-          wrapError(
-            'articles',
-            'create',
-            ERROR_TYPES.ENTITY_NOT_FOUND,
-            `Folder ${folderId} not found or not accessible. Verify the folder_id or provide company_id directly.`,
-            'Provide a valid folder_id, a numeric company_id, or set global=true for a global article.',
-          ),
-        ),
+        errorJson: JSON.stringify(formatApiError(
+          `Folder ${folderId} lookup failed: ${msg}`,
+          'articles',
+          'create',
+        )),
       };
     }
   }

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -112,6 +112,75 @@ function getWriteEndpointAndFields(
   };
 }
 
+async function resolveArticleCreateContext(
+  params: Record<string, unknown>,
+  context: ISupplyDataFunctions,
+): Promise<{ resolvedParams: Record<string, unknown>; errorJson?: string }> {
+  const isGlobal = params.global === true;
+  const companyId = params.company_id;
+  const folderId = params.folder_id;
+
+  // Strip client-only field — never reaches Hudu API
+  const { global: _global, ...rest } = params;
+  let resolved = rest;
+
+  // global=true wins; strip company_id too
+  if (isGlobal) {
+    const { company_id: _cid, ...withoutCompany } = resolved;
+    return { resolvedParams: withoutCompany };
+  }
+
+  // company_id present — no resolution needed
+  if (companyId !== undefined && companyId !== null) {
+    return { resolvedParams: resolved };
+  }
+
+  // folder_id present — resolve company_id from folder
+  if (folderId !== undefined && folderId !== null) {
+    try {
+      const folderData = await handleGetOperation.call(
+        context as unknown as IExecuteFunctions,
+        '/folders',
+        folderId as number,
+        'folder',
+      );
+      const folder = folderData as Record<string, unknown>;
+      if (folder.company_id !== undefined && folder.company_id !== null) {
+        resolved = { ...resolved, company_id: folder.company_id };
+      }
+      // folder.company_id === null → global folder, proceed without company_id
+      return { resolvedParams: resolved };
+    } catch {
+      return {
+        resolvedParams: resolved,
+        errorJson: JSON.stringify(
+          wrapError(
+            'articles',
+            'create',
+            ERROR_TYPES.ENTITY_NOT_FOUND,
+            `Folder ${folderId} not found or not accessible. Verify the folder_id or provide company_id directly.`,
+            'Provide a valid folder_id, a numeric company_id, or set global=true for a global article.',
+          ),
+        ),
+      };
+    }
+  }
+
+  // No identifiers — require the LLM to provide one
+  return {
+    resolvedParams: resolved,
+    errorJson: JSON.stringify(
+      wrapError(
+        'articles',
+        'create',
+        ERROR_TYPES.MISSING_REQUIRED_FIELD,
+        'company_id, folder_id, or global=true is required to create an article.',
+        'Provide a numeric company_id, a folder_id (company auto-resolved from folder), or set global=true to create a global article. Call hudu_companies_get_id_by_name to resolve a company name to its numeric ID.',
+      ),
+    ),
+  };
+}
+
 export async function executeHuduAiTool(
   context: ISupplyDataFunctions,
   resource: string,
@@ -293,11 +362,19 @@ export async function executeHuduAiTool(
       }
 
       case 'create': {
+        // Articles: resolve company_id from folder_id if absent, handle global flag
+        let createParams = params;
+        if (resource === 'articles') {
+          const { resolvedParams, errorJson } = await resolveArticleCreateContext(params, context);
+          if (errorJson) return errorJson;
+          createParams = resolvedParams;
+        }
+
         // For company-endpoint resources (assets), strip company_id from body and
         // use it for endpoint routing instead. For all other resources, company_id
         // must remain in the body as a regular API field.
         const { endpoint, fields } = getWriteEndpointAndFields(
-          params,
+          createParams,
           config.endpoint,
           config.requiresCompanyEndpoint,
         );


### PR DESCRIPTION
## Summary

- `articles create` now auto-resolves `company_id` from `folder_id` via an internal `GET /folders/{id}` call — no separate company lookup needed when folder ID is known
- New `global` boolean field (default `false`) opts into global articles; `global=true` strips `company_id` and skips resolution
- Structured errors returned when neither `company_id`, `folder_id`, nor `global=true` provided
- Updated schema descriptions and tool description to guide LLM to correct scope pattern

## Decision tree

| Input | Behaviour |
|-------|-----------|
| `global=true` | Creates global article; `company_id` stripped |
| `company_id` present | Creates directly, no folder fetch |
| `folder_id` only | Fetches folder → injects `company_id` → creates |
| None | Returns `MISSING_REQUIRED_FIELD` error |

## Test Plan

- [ ] `folder_id` only → article created under correct company
- [ ] `company_id` only → creates directly
- [ ] Both provided → no folder fetch
- [ ] `global=true` → no `company_id` in created record
- [ ] `global=true` + `folder_id` → article in folder, no `company_id`
- [ ] `global=true` + `company_id` → `company_id` stripped, global wins
- [ ] No identifiers → structured error returned
- [ ] Bad `folder_id` → `ENTITY_NOT_FOUND` error returned
- [ ] Null-`company_id` folder → article created with `folder_id` only