### PR TITLE
fix(aitools): harden runtime resolution — documented require.cache, zod cache-scan fallback, optional peerDeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ All notable changes to this project will be documented in this file.
 
 - **[MEDIUM] ~~`HuduAiTools` AI tool output connection type~~** — Fixed in 2.5.0: `NodeConnectionTypes.AiTool` enum value now used in place of the `’ai_tool’ as NodeConnectionType` string cast.
 
+## [2.6.1] - 2026-07-08
+
+### Changed
+- **`findCachedExports()` now reads the documented `require.cache` instead of the internal `Module._cache`.** `require.cache` is the public CommonJS alias that points at the exact same underlying module-cache object, and is available directly in CJS module scope (this file compiles to CJS via tsc), so the fallback no longer needs `require('module')` at all. Behaviour is identical; the change removes a dependency on an undocumented Node internal and drops one `require('module')` call from the AI tools runtime.
+- **`zod` resolution now has a `require.cache`-scan fallback, mirroring `DynamicStructuredTool`.** Previously zod was resolved eagerly at module load via `require.main` (`_topLevelZodReq`) then the `@langchain/classic`/`langchain` anchor (`runtimeReq`), with **no** cache-scan fallback — so on pnpm-strict-isolated n8n installs (v2.29.x+) where neither anchor can reach n8n's zod, `_runtimeZod` stayed `undefined` and every `runtimeZod` Proxy access threw forever. This is the same failure class that issue #26's fix already handled for `@langchain/core/tools`. Resolution is now lazy (on first Proxy access) via `resolveRuntimeZod()`: it keeps the require.main-first ordering as the primary path (nothing regresses for the common working case), then falls back to scanning `require.cache` for the zod namespace once it's resident, validating the exports look like zod (`ZodType` and `object` are functions — n8n's `normalizeToolSchema` does `instanceof ZodType`) and preserving class identity. Memoization is result-based (only on success), so it retries until it resolves once. The cache-scan path regex is narrowed to zod's own entry files (`lib`/`dist`/`index`/`v3`/`v4`) so it never matches `zod-to-json-schema` or other zod-adjacent packages.
+
+### Added
+- **`@langchain/core` and `@n8n/ai-utilities` declared as optional `peerDependencies`.** These are host-provided by n8n at runtime (never installed by this package — installing a duplicate copy would break n8n's `instanceof` class-identity checks). Declaring them as optional peers documents the host-provided contract and gives an install-time drift signal without changing resolution. `n8n-workflow` remains a required (non-optional) peer.
+
 ## [2.6.0] - 2026-07-08
 
 ### Fixed

--- a/nodes/Hudu/ai-tools/runtime.ts
+++ b/nodes/Hudu/ai-tools/runtime.ts
@@ -96,13 +96,16 @@ function findCachedExports<T>(
   validate: (exports: Record<string, unknown>) => T | undefined,
 ): T | undefined {
   try {
-    // eslint-disable-next-line @n8n/community-nodes/no-restricted-imports, @typescript-eslint/no-require-imports
-    const Module = require('module') as { _cache?: Record<string, { exports: unknown }> };
-    const cache = Module._cache;
+    // require.cache is the public, documented CommonJS alias that points at the exact
+    // same underlying object as the internal Module._cache. It is available directly in
+    // CJS module scope (this file compiles to CJS via tsc), so no require('module') needed.
+    const cache = require.cache;
     if (!cache) return undefined;
     for (const key of Object.keys(cache)) {
       if (!pathPattern.test(key)) continue;
-      const result = validate(cache[key].exports as Record<string, unknown>);
+      const entry = cache[key];
+      if (!entry) continue;
+      const result = validate(entry.exports as Record<string, unknown>);
       if (result !== undefined) return result;
     }
   } catch (_) {
@@ -113,6 +116,7 @@ function findCachedExports<T>(
 
 const { runtimeReq, diagnostic } = getRuntimeRequire();
 let langchainResolutionDiagnostic = diagnostic;
+let zodResolutionDiagnostic = diagnostic;
 
 // Resolve zod SEPARATELY via require.main to get the top-level zod instance
 // that n8n's normalizeToolSchema uses for `instanceof ZodType` checks.
@@ -165,19 +169,48 @@ function resolveDynamicStructuredTool(): DynamicStructuredToolCtor | undefined {
   return _RuntimeDynamicStructuredTool;
 }
 
-// Resolve zod via require.main first (top-level copy used by n8n's instanceof check).
-// Fall back to the anchor runtimeReq only if require.main is unavailable.
-if (_topLevelZodReq) {
-  try {
-    _runtimeZod = _topLevelZodReq('zod') as RuntimeZod;
-  } catch (_) {}
-}
-if (!_runtimeZod && runtimeReq) {
-  try {
-    _runtimeZod = runtimeReq('zod') as RuntimeZod;
-  } catch (e) {
-    zodLoadError = e instanceof Error ? e.message : String(e);
+function resolveRuntimeZod(): RuntimeZod | undefined {
+  if (_runtimeZod) return _runtimeZod;
+
+  // Primary path: require.main → top-level zod (the copy n8n's normalizeToolSchema uses
+  // for `instanceof ZodType`). Preserved as the first attempt so the common, working
+  // install resolves exactly as before this became lazy.
+  if (_topLevelZodReq) {
+    try {
+      _runtimeZod = _topLevelZodReq('zod') as RuntimeZod;
+      if (_runtimeZod) return _runtimeZod;
+    } catch (_) {}
   }
+
+  // Fall back to the anchor runtimeReq if require.main is unavailable/failed.
+  if (runtimeReq) {
+    try {
+      _runtimeZod = runtimeReq('zod') as RuntimeZod;
+      if (_runtimeZod) return _runtimeZod;
+    } catch (e) {
+      zodLoadError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // Fallback for pnpm-isolated installs where no filesystem anchor reaches zod at all
+  // (same failure class resolveDynamicStructuredTool() handles for @langchain/core):
+  // scan require.cache for the zod namespace once it's resident. Validate the exports
+  // look like zod by confirming ZodType is a function (n8n's normalizeToolSchema does
+  // `instanceof ZodType`, so ZodType must be present and be the same class identity) and
+  // that the `object` factory is present (our schema-generator calls z.object). The path
+  // regex is narrowed to zod's own entry files so it never matches zod-to-json-schema or
+  // other zod-adjacent packages; the exports-shape check is the real safety net.
+  const cached = findCachedExports(/[\\/]zod[\\/](lib|dist|index|v3|v4)/, (exports) =>
+    typeof exports['ZodType'] === 'function' && typeof exports['object'] === 'function'
+      ? (exports as unknown as RuntimeZod)
+      : undefined,
+  );
+  if (cached) {
+    _runtimeZod = cached;
+    zodLoadError = null;
+    zodResolutionDiagnostic = 'resolved via require.cache scan (pnpm-isolated install)';
+  }
+  return _runtimeZod;
 }
 
 // IMPORTANT: Proxy target MUST be `function () {}`, not `{}`.
@@ -216,16 +249,17 @@ export const runtimeZod: RuntimeZod = new Proxy({} as RuntimeZod, {
     // Guard: frameworks probe Symbol.toPrimitive, Symbol.toStringTag, .then (Promise thenable),
     // and .constructor. Throwing on these causes misleading errors during structural inspection.
     if (typeof prop === 'symbol' || prop === 'then' || prop === 'constructor') return undefined;
-    if (!_runtimeZod) {
+    const zod = resolveRuntimeZod();
+    if (!zod) {
       throw new Error(
         `runtimeZod: zod could not be resolved from n8n's module tree (accessing .${String(prop)}). ` +
         'Ensure zod is installed in the n8n environment.' +
-        (diagnostic ? ` Diagnostic: ${diagnostic}` : '') +
+        (zodResolutionDiagnostic ? ` Diagnostic: ${zodResolutionDiagnostic}` : '') +
         (zodLoadError ? ` Load error: ${zodLoadError}` : ''),
       );
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (_runtimeZod as any)[prop];
+    return (zod as any)[prop];
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-hudu",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "This n8n custom node facilitates integration with Hudu's API.",
   "keywords": [
     "n8n-community-node-package",
@@ -36,7 +36,17 @@
     "dist"
   ],
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "*",
+    "@langchain/core": "*",
+    "@n8n/ai-utilities": "*"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
+    "@n8n/ai-utilities": {
+      "optional": true
+    }
   },
   "n8n": {
     "n8nNodesApiVersion": 1,


### PR DESCRIPTION
## Summary

Follow-up hardening from the issue #26 strategic review (the fix shipped in PR #27 / v2.6.0). Three robustness changes to `nodes/Hudu/ai-tools/runtime.ts` + `package.json`, no new user-facing feature (patch **2.6.0 → 2.6.1**).

### 1. `findCachedExports()` uses documented `require.cache` instead of internal `Module._cache`
The cache-scan fallback added in #27 read `require('module')._cache` — an undocumented Node internal. `require.cache` is the public CommonJS alias pointing at the exact same underlying object, and is available directly in CJS module scope (this file compiles to CJS via tsc), so the `require('module')` call is dropped entirely. Behaviour is identical.

### 2. zod resolution gains a `require.cache`-scan fallback (mirrors `DynamicStructuredTool`)
Previously zod was resolved **eagerly at module load** via `require.main` then the `@langchain/classic`/`langchain` anchor, with **no** cache-scan fallback. Under pnpm-strict-isolated n8n installs (v2.29.x+) where neither anchor reaches n8n's zod, `_runtimeZod` stayed `undefined` and every `runtimeZod` Proxy access threw forever — the same failure class #27 fixed for `@langchain/core/tools`, but left unaddressed for zod.

zod resolution is now **lazy** via `resolveRuntimeZod()`, which:
- keeps the require.main-first ordering as the **primary path** (nothing regresses for the common working install);
- falls back to `runtimeReq('zod')`;
- as a final fallback scans `require.cache`, validating the exports look like zod (`ZodType` **and** `object` are functions — n8n's `normalizeToolSchema` does `instanceof ZodType`), preserving class identity;
- memoizes **result-based** (only on success), so it retries until resolved once (never the flag-before-attempt bug fixed earlier in `getLazyLogWrapper`).

The cache-scan path regex is narrowed to zod's own entry files (`/[\\/]zod[\\/](lib|dist|index|v3|v4)/`) so it never matches `zod-to-json-schema` or other zod-adjacent packages; the exports-shape check is the real safety net.

### 3. Optional `peerDependencies`
`@langchain/core` and `@n8n/ai-utilities` declared as **optional** peers. These are host-provided by n8n at runtime and are deliberately **not** in `dependencies` (a duplicate copy would break `instanceof` class identity). This documents the host-provided contract and gives an install-time drift signal without changing resolution. `n8n-workflow` stays a required peer.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean (exit 0)
- `npm run build` — succeeds (compiles as 2.6.1)
- `npx eslint nodes/Hudu/ai-tools/runtime.ts` — **8 errors, identical categories to baseline** (`__filename` ×2, unused `_` ×4, empty-block ×2). Zero new categories; the refactor moved one `catch (_) {}` from the removed eager block into `resolveRuntimeZod()`, net delta 0.
- Node smoke test against rebuilt `dist/.../runtime.js` (injects fake `@langchain/core` + `zod` entries into `require.cache` at fake absolute paths, run from a dir where the filesystem anchors cannot resolve, so the cache scan is the only success path):

```
PASS — runtimeZod resolves injected fake via require.cache scan :: __sentinel=zod-cache-scan
PASS — runtimeZod.ZodType is the fake class (identity preserved)
PASS — runtimeZod.object is the fake factory (namespace usable)
PASS — tightened regex did NOT pick the zod-to-json-schema decoy
PASS — RuntimeDynamicStructuredTool resolves injected fake @langchain/core via require.cache scan :: __fake=langchain-cache-scan
PASS — constructed tool carries through fields

ALL SMOKE TESTS PASSED
```

## Notes
- `dist/` is gitignored in this repo (regenerated on publish via `prepublishOnly`), so no `dist/**` files are committed — only source. The build was still run to produce the artifact the smoke test exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)