### PR TITLE
fix(ai-tools): pass execution context to logWrapper (fixes #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
 
 - **[MEDIUM] ~~`HuduAiTools` AI tool output connection type~~** — Fixed in 2.5.0: `NodeConnectionTypes.AiTool` enum value now used in place of the `’ai_tool’ as NodeConnectionType` string cast.
 
+## [2.6.3] - 2026-07-09
+
+### Fixed
+- **`HuduAiTools` tool calls fail with `addInputData is not a function` when connected via MCP Server Trigger (issue #31).** `logWrapper` in `supplyData()` was passed `this.getNode()` (static `INode` descriptor) instead of `this` (`ISupplyDataFunctions` execution context). n8n's tool-call logging proxy invokes `addInputData` on every invocation before the tool handler runs, so every call threw immediately — including read-only ops like `help` that never touch the Hudu API.
+
 ## [2.6.2] - 2026-07-08
 
 ### Changed

--- a/nodes/Hudu/HuduAiTools.node.ts
+++ b/nodes/Hudu/HuduAiTools.node.ts
@@ -260,7 +260,7 @@ export class HuduAiTools implements INodeType {
         });
 
         const logWrapper = getLazyLogWrapper();
-        const wrappedTool = logWrapper ? logWrapper(unifiedTool, this.getNode()) : unifiedTool;
+        const wrappedTool = logWrapper ? logWrapper(unifiedTool, this) : unifiedTool;
         return { response: wrappedTool as typeof unifiedTool };
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-hudu",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "This n8n custom node facilitates integration with Hudu's API.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Fixes #31 — `HuduAiTools` tool calls no longer throw `executeFunctions.addInputData is not a function` when connected via MCP Server Trigger
- `logWrapper` in `supplyData()` now receives `this` (`ISupplyDataFunctions`) instead of `this.getNode()` (`INode`)
- Patch release 2.6.3

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] MCP Server Trigger workflow: `hudu_articles` `help` returns static help text (no TypeError)
- [ ] MCP Server Trigger workflow: `hudu_articles` `getAll` returns results
- [ ] MCP Server Trigger workflow: `hudu_companies` `getAll` returns results
- [ ] AI Agent node (non-MCP) path still works — regression check
- [ ] Tool call logging visible in n8n execution view when `@n8n/ai-utilities` is present