### PR TITLE
docs: fix README AI Tools unified tool wording (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - README API compatibility line updated to **2.44.0**.
+- README Hudu AI Tools section now documents the **unified tool** model — one `hudu_{resource}` tool per resource with a required `operation` enum — instead of the obsolete per-operation names like `hudu_companies_getAll` (issue #35).
 
 ## [2.6.3] - 2026-07-09
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To use this node, you need to:
 
 ## Hudu AI Tools Node
 
-The `Hudu AI Tools` node connects to n8n's **AI Agent** and exposes Hudu operations as individual structured tools that an LLM can invoke directly.
+The `Hudu AI Tools` node connects to n8n's **AI Agent** and exposes Hudu as unified structured tools that an LLM can invoke directly.
 
 ### How it works
 
@@ -207,7 +207,7 @@ The `Hudu AI Tools` node connects to n8n's **AI Agent** and exposes Hudu operati
 3. Select a **Resource** and the **Operations** to expose
 4. Optionally enable **Allow Write Operations** to permit create / update / delete / archive
 
-The AI Agent receives one named tool per operation (e.g. `hudu_companies_getAll`, `hudu_assets_create`) and can call them autonomously based on the user's request. The `get` operation is exposed as `getById` (e.g. `hudu_companies_getById`) so the LLM clearly understands a numeric ID is required.
+The AI Agent receives **one tool per resource** (e.g. `hudu_companies`, `hudu_assets`), not one tool per operation. Each tool requires an `operation` field (`get`, `getAll`, `create`, `update`, `delete`, and other resource-specific ops) that selects the action. Use `operation: 'get'` only when you already have a numeric ID from a prior `getAll` (or similar) result.
 
 ### Supported resources
 


### PR DESCRIPTION
## Summary
- Update README Hudu AI Tools section to describe the unified architecture: one `hudu_{resource}` tool per resource with a required `operation` enum
- Remove stale per-operation examples (`hudu_companies_getAll`, `getById`)
- Note under existing **2.7.0** changelog (no version bump) — closes #35

## Test plan
- [ ] README "How it works" matches current `HuduAiTools` tool naming (`hudu_${resource}`)
- [ ] No remaining per-operation tool name examples in that section


Made with [Cursor](https://cursor.com)