### PR TITLE
feat(assets): Markdown input for RichText custom fields on create/update (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **Markdown content input for Assets RichText custom fields** (issue #37). A new `Fields Format: HTML | Markdown` option on Asset create/update converts RichText custom-field values from Markdown to HTML via `marked` before sending to Hudu. Both the regular node and **Hudu AI Tools** (`fields_format` write flag) resolve the asset layout and convert only fields whose type is RichText (`field_type === 'RichText'`), leaving Date/List/Text and other field types untouched. Default remains `html` (values sent as-is), so existing workflows are unaffected.
 
+### Changed
+- **Hudu AI Tools asset writes normalise `custom_fields` to Hudu's label-keyed shape.** Entries supplied as `{ asset_layout_field_id, value }` are now rewritten to the `{ <snake_case label>: value }` objects the Hudu API expects (matching the regular node's payload builder) by resolving the asset layout, so those writes persist instead of being ignored. Label/snake_case-keyed entries are forwarded unchanged.
+
 ## [2.8.1] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 `n8n-nodes-hudu` (this package) is the **full, self-hosted** edition — it includes the dedicated **Hudu AI Tools** node (`HuduAiTools`, a unified per-resource AI/MCP tool) and therefore carries an AI/LangChain runtime dependency, so it cannot be verified for **n8n Cloud** (the hosted n8n platform). A zero-dependency subset that *is* n8n-Cloud-verifiable is published separately as **[n8n-nodes-hudu-core](https://github.com/msoukhomlinov/n8n-nodes-hudu-core)** — same `Hudu` node (AI Agent tool use via `usableAsTool`), without the dedicated AI Tools node. Both talk to the same Hudu API regardless of how your Hudu instance is hosted.
 
+## [2.9.0] - 2026-07-22
+
+### Added
+- **Markdown content input for Assets RichText custom fields** (issue #37). A new `Fields Format: HTML | Markdown` option on Asset create/update converts RichText custom-field values from Markdown to HTML via `marked` before sending to Hudu. On the regular node, RichText fields are detected from the asset layout (`field_type === 'RichText'`) so only those values are converted. On **Hudu AI Tools**, a matching `fields_format` write flag converts the string `value` of each `custom_fields` entry. Default remains `html` (values sent as-is), so existing workflows are unaffected.
+
 ## [2.8.1] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ## [2.9.0] - 2026-07-22
 
 ### Added
-- **Markdown content input for Assets RichText custom fields** (issue #37). A new `Fields Format: HTML | Markdown` option on Asset create/update converts RichText custom-field values from Markdown to HTML via `marked` before sending to Hudu. On the regular node, RichText fields are detected from the asset layout (`field_type === 'RichText'`) so only those values are converted. On **Hudu AI Tools**, a matching `fields_format` write flag converts the string `value` of each `custom_fields` entry. Default remains `html` (values sent as-is), so existing workflows are unaffected.
+- **Markdown content input for Assets RichText custom fields** (issue #37). A new `Fields Format: HTML | Markdown` option on Asset create/update converts RichText custom-field values from Markdown to HTML via `marked` before sending to Hudu. Both the regular node and **Hudu AI Tools** (`fields_format` write flag) resolve the asset layout and convert only fields whose type is RichText (`field_type === 'RichText'`), leaving Date/List/Text and other field types untouched. Default remains `html` (values sent as-is), so existing workflows are unaffected.
 
 ## [2.8.1] - 2026-07-22
 

--- a/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
+++ b/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
@@ -2,51 +2,107 @@ import { describe, it, expect } from 'vitest';
 import { applyAssetFieldsFormat } from '../tool-executor';
 
 describe('applyAssetFieldsFormat', () => {
-  it('converts markdown only for RichText field IDs and strips fields_format', () => {
+  describe('{ asset_layout_field_id, value } shape', () => {
+    it('converts markdown only for RichText field IDs and strips fields_format', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [
+            { asset_layout_field_id: 1, value: '**bold**' },
+            { asset_layout_field_id: 2, value: 'plain text' },
+          ],
+        },
+        new Set(['1']),
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields).toHaveLength(2);
+      expect(fields[0].value).toContain('<strong>');
+      // Field 2 is not RichText → left untouched
+      expect(fields[1].value).toBe('plain text');
+      expect(result).not.toHaveProperty('fields_format');
+    });
+
+    it('matches asset_layout_field_id supplied as a string', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [{ asset_layout_field_id: '5', value: '# Title' }],
+        },
+        new Set(['5']),
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields[0].value).toContain('<h1');
+    });
+
+    it('skips non-string values on RichText fields', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [
+            { asset_layout_field_id: 1, value: 42 },
+            { asset_layout_field_id: 2, value: null },
+          ],
+        },
+        new Set(['1', '2']),
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields[0].value).toBe(42);
+      expect(fields[1].value).toBeNull();
+    });
+  });
+
+  describe('label / snake_case-keyed shape', () => {
+    it('converts a RichText value keyed by snake_case label', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [
+            { notes: '**bold**' },
+            { serial_number: 'ABC-123' },
+          ],
+        },
+        new Set(['notes']),
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields[0].notes).toContain('<strong>');
+      // serial_number is not RichText → untouched
+      expect(fields[1].serial_number).toBe('ABC-123');
+    });
+
+    it('converts a RichText value keyed by raw label', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [{ Notes: '# Heading' }],
+        },
+        new Set(['Notes']),
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields[0].Notes).toContain('<h1');
+    });
+  });
+
+  it('leaves all custom_fields untouched when the RichText key set is empty', () => {
     const result = applyAssetFieldsFormat(
       {
         fields_format: 'markdown',
         custom_fields: [
           { asset_layout_field_id: 1, value: '**bold**' },
-          { asset_layout_field_id: 2, value: 'plain text' },
+          { notes: '**bold**' },
         ],
-      },
-      new Set([1]),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields).toHaveLength(2);
-    expect(fields[0].value).toContain('<strong>');
-    // Field 2 is not RichText → left untouched
-    expect(fields[1].value).toBe('plain text');
-    expect(result).not.toHaveProperty('fields_format');
-  });
-
-  it('leaves all custom_fields untouched when the RichText id set is empty', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'markdown',
-        custom_fields: [{ asset_layout_field_id: 1, value: '**bold**' }],
       },
       new Set(),
     );
 
     const fields = result.custom_fields as Record<string, unknown>[];
     expect(fields[0].value).toBe('**bold**');
+    expect(fields[1].notes).toBe('**bold**');
     expect(result).not.toHaveProperty('fields_format');
-  });
-
-  it('matches asset_layout_field_id supplied as a string', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'markdown',
-        custom_fields: [{ asset_layout_field_id: '5', value: '# Title' }],
-      },
-      new Set([5]),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].value).toContain('<h1');
   });
 
   it('leaves custom_fields unchanged when fields_format is html, but strips the flag', () => {
@@ -55,7 +111,7 @@ describe('applyAssetFieldsFormat', () => {
         fields_format: 'html',
         custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
       },
-      new Set([1]),
+      new Set(['1']),
     );
 
     const fields = result.custom_fields as Record<string, unknown>[];
@@ -66,31 +122,14 @@ describe('applyAssetFieldsFormat', () => {
   it('leaves custom_fields unchanged when fields_format is absent, but strips the flag', () => {
     const result = applyAssetFieldsFormat(
       {
-        custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
+        custom_fields: [{ notes: '**bold**' }],
       },
-      new Set([1]),
+      new Set(['notes']),
     );
 
     const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].value).toBe('<p>hi</p>');
+    expect(fields[0].notes).toBe('**bold**');
     expect(result).not.toHaveProperty('fields_format');
-  });
-
-  it('skips non-string values on RichText fields', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'markdown',
-        custom_fields: [
-          { asset_layout_field_id: 1, value: 42 },
-          { asset_layout_field_id: 2, value: null },
-        ],
-      },
-      new Set([1, 2]),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].value).toBe(42);
-    expect(fields[1].value).toBeNull();
   });
 
   it('returns params unchanged (minus fields_format) when custom_fields is absent', () => {
@@ -99,7 +138,7 @@ describe('applyAssetFieldsFormat', () => {
         fields_format: 'markdown',
         name: 'Test Asset',
       },
-      new Set([1]),
+      new Set(['1']),
     );
 
     expect(result).toEqual({ name: 'Test Asset' });

--- a/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
+++ b/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { applyAssetFieldsFormat } from '../tool-executor';
+
+describe('applyAssetFieldsFormat', () => {
+  it('converts markdown string values in custom_fields to HTML and strips fields_format', () => {
+    const result = applyAssetFieldsFormat({
+      fields_format: 'markdown',
+      custom_fields: [
+        { asset_layout_field_id: '1', value: '**bold**' },
+        { asset_layout_field_id: '2', value: 'plain text' },
+      ],
+    });
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields).toHaveLength(2);
+    expect(fields[0].value).toContain('<strong>');
+    expect(fields[1].value).toBe('<p>plain text</p>\n');
+    expect(result).not.toHaveProperty('fields_format');
+  });
+
+  it('leaves custom_fields unchanged when fields_format is html, but strips the flag', () => {
+    const result = applyAssetFieldsFormat({
+      fields_format: 'html',
+      custom_fields: [{ asset_layout_field_id: '1', value: '<p>hi</p>' }],
+    });
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].value).toBe('<p>hi</p>');
+    expect(result).not.toHaveProperty('fields_format');
+  });
+
+  it('leaves custom_fields unchanged when fields_format is absent, but strips the flag', () => {
+    const result = applyAssetFieldsFormat({
+      custom_fields: [{ asset_layout_field_id: '1', value: '<p>hi</p>' }],
+    });
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].value).toBe('<p>hi</p>');
+    expect(result).not.toHaveProperty('fields_format');
+  });
+
+  it('skips non-string values in custom_fields', () => {
+    const result = applyAssetFieldsFormat({
+      fields_format: 'markdown',
+      custom_fields: [
+        { asset_layout_field_id: '1', value: 42 },
+        { asset_layout_field_id: '2', value: null },
+      ],
+    });
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].value).toBe(42);
+    expect(fields[1].value).toBeNull();
+  });
+
+  it('does not convert the asset_layout_field_id key', () => {
+    const result = applyAssetFieldsFormat({
+      fields_format: 'markdown',
+      custom_fields: [{ asset_layout_field_id: '**1**', value: 'test' }],
+    });
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].asset_layout_field_id).toBe('**1**');
+  });
+
+  it('returns params unchanged (minus fields_format) when custom_fields is absent', () => {
+    const result = applyAssetFieldsFormat({
+      fields_format: 'markdown',
+      name: 'Test Asset',
+    });
+
+    expect(result).toEqual({ name: 'Test Asset' });
+    expect(result).not.toHaveProperty('fields_format');
+  });
+});

--- a/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
+++ b/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
@@ -1,144 +1,117 @@
 import { describe, it, expect } from 'vitest';
 import { applyAssetFieldsFormat } from '../tool-executor';
+import type { IAssetLayoutFieldEntity } from '../../resources/asset_layout_fields/asset_layout_fields.types';
+
+// Minimal layout field factory — only the properties applyAssetFieldsFormat reads.
+function field(id: number, label: string, fieldType: string): IAssetLayoutFieldEntity {
+  return { id, label, field_type: fieldType } as unknown as IAssetLayoutFieldEntity;
+}
+
+const layout: IAssetLayoutFieldEntity[] = [
+  field(1, 'Notes', 'RichText'),
+  field(2, 'Serial Number', 'Text'),
+  field(3, 'OAuth Token', 'RichText'),
+];
 
 describe('applyAssetFieldsFormat', () => {
-  describe('{ asset_layout_field_id, value } shape', () => {
-    it('converts markdown only for RichText field IDs and strips fields_format', () => {
+  describe('{ asset_layout_field_id, value } shape → rewritten to label-keyed', () => {
+    it('rewrites to snake_case label keys and converts only RichText values (markdown)', () => {
       const result = applyAssetFieldsFormat(
         {
           fields_format: 'markdown',
           custom_fields: [
             { asset_layout_field_id: 1, value: '**bold**' },
-            { asset_layout_field_id: 2, value: 'plain text' },
+            { asset_layout_field_id: 2, value: 'ABC-123' },
           ],
         },
-        new Set(['1']),
+        layout,
       );
 
       const fields = result.custom_fields as Record<string, unknown>[];
       expect(fields).toHaveLength(2);
-      expect(fields[0].value).toContain('<strong>');
-      // Field 2 is not RichText → left untouched
-      expect(fields[1].value).toBe('plain text');
+      // RichText → converted, keyed by snake_case label; no asset_layout_field_id/value keys remain
+      expect(fields[0]).not.toHaveProperty('asset_layout_field_id');
+      expect(fields[0].notes).toContain('<strong>');
+      // Non-RichText → value preserved, still rewritten to label key
+      expect(fields[1].serial_number).toBe('ABC-123');
       expect(result).not.toHaveProperty('fields_format');
     });
 
-    it('matches asset_layout_field_id supplied as a string', () => {
+    it('rewrites to label-keyed even when not markdown (Hudu shape requirement)', () => {
       const result = applyAssetFieldsFormat(
         {
-          fields_format: 'markdown',
-          custom_fields: [{ asset_layout_field_id: '5', value: '# Title' }],
+          fields_format: 'html',
+          custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
         },
-        new Set(['5']),
+        layout,
       );
 
       const fields = result.custom_fields as Record<string, unknown>[];
-      expect(fields[0].value).toContain('<h1');
+      expect(fields[0].notes).toBe('<p>hi</p>');
+      expect(fields[0]).not.toHaveProperty('asset_layout_field_id');
     });
 
-    it('skips non-string values on RichText fields', () => {
+    it('uses the API snake_case transform for acronym/digit labels', () => {
       const result = applyAssetFieldsFormat(
         {
           fields_format: 'markdown',
-          custom_fields: [
-            { asset_layout_field_id: 1, value: 42 },
-            { asset_layout_field_id: 2, value: null },
-          ],
+          custom_fields: [{ asset_layout_field_id: 3, value: '# Title' }],
         },
-        new Set(['1', '2']),
+        layout,
       );
 
       const fields = result.custom_fields as Record<string, unknown>[];
-      expect(fields[0].value).toBe(42);
-      expect(fields[1].value).toBeNull();
+      expect(fields[0].oauth_token).toContain('<h1');
+    });
+
+    it('leaves an entry untouched when its id is unknown to the layout', () => {
+      const result = applyAssetFieldsFormat(
+        {
+          fields_format: 'markdown',
+          custom_fields: [{ asset_layout_field_id: 99, value: '**bold**' }],
+        },
+        layout,
+      );
+
+      const fields = result.custom_fields as Record<string, unknown>[];
+      expect(fields[0].asset_layout_field_id).toBe(99);
+      expect(fields[0].value).toBe('**bold**');
     });
   });
 
-  describe('label / snake_case-keyed shape', () => {
-    it('converts a RichText value keyed by snake_case label', () => {
+  describe('label / snake_case-keyed shape (already Hudu-shaped)', () => {
+    it('converts RichText values in place when markdown', () => {
       const result = applyAssetFieldsFormat(
         {
           fields_format: 'markdown',
-          custom_fields: [
-            { notes: '**bold**' },
-            { serial_number: 'ABC-123' },
-          ],
+          custom_fields: [{ notes: '**bold**' }, { serial_number: 'ABC-123' }],
         },
-        new Set(['notes']),
+        layout,
       );
 
       const fields = result.custom_fields as Record<string, unknown>[];
       expect(fields[0].notes).toContain('<strong>');
-      // serial_number is not RichText → untouched
       expect(fields[1].serial_number).toBe('ABC-123');
     });
 
-    it('converts a RichText value keyed by raw label', () => {
+    it('leaves values untouched when not markdown', () => {
       const result = applyAssetFieldsFormat(
         {
-          fields_format: 'markdown',
-          custom_fields: [{ Notes: '# Heading' }],
+          fields_format: 'html',
+          custom_fields: [{ notes: '**bold**' }],
         },
-        new Set(['Notes']),
+        layout,
       );
 
       const fields = result.custom_fields as Record<string, unknown>[];
-      expect(fields[0].Notes).toContain('<h1');
+      expect(fields[0].notes).toBe('**bold**');
     });
-  });
-
-  it('leaves all custom_fields untouched when the RichText key set is empty', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'markdown',
-        custom_fields: [
-          { asset_layout_field_id: 1, value: '**bold**' },
-          { notes: '**bold**' },
-        ],
-      },
-      new Set(),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].value).toBe('**bold**');
-    expect(fields[1].notes).toBe('**bold**');
-    expect(result).not.toHaveProperty('fields_format');
-  });
-
-  it('leaves custom_fields unchanged when fields_format is html, but strips the flag', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'html',
-        custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
-      },
-      new Set(['1']),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].value).toBe('<p>hi</p>');
-    expect(result).not.toHaveProperty('fields_format');
-  });
-
-  it('leaves custom_fields unchanged when fields_format is absent, but strips the flag', () => {
-    const result = applyAssetFieldsFormat(
-      {
-        custom_fields: [{ notes: '**bold**' }],
-      },
-      new Set(['notes']),
-    );
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].notes).toBe('**bold**');
-    expect(result).not.toHaveProperty('fields_format');
   });
 
   it('returns params unchanged (minus fields_format) when custom_fields is absent', () => {
     const result = applyAssetFieldsFormat(
-      {
-        fields_format: 'markdown',
-        name: 'Test Asset',
-      },
-      new Set(['1']),
+      { fields_format: 'markdown', name: 'Test Asset' },
+      layout,
     );
 
     expect(result).toEqual({ name: 'Test Asset' });

--- a/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
+++ b/nodes/Hudu/ai-tools/__tests__/applyAssetFieldsFormat.test.ts
@@ -2,27 +2,61 @@ import { describe, it, expect } from 'vitest';
 import { applyAssetFieldsFormat } from '../tool-executor';
 
 describe('applyAssetFieldsFormat', () => {
-  it('converts markdown string values in custom_fields to HTML and strips fields_format', () => {
-    const result = applyAssetFieldsFormat({
-      fields_format: 'markdown',
-      custom_fields: [
-        { asset_layout_field_id: '1', value: '**bold**' },
-        { asset_layout_field_id: '2', value: 'plain text' },
-      ],
-    });
+  it('converts markdown only for RichText field IDs and strips fields_format', () => {
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'markdown',
+        custom_fields: [
+          { asset_layout_field_id: 1, value: '**bold**' },
+          { asset_layout_field_id: 2, value: 'plain text' },
+        ],
+      },
+      new Set([1]),
+    );
 
     const fields = result.custom_fields as Record<string, unknown>[];
     expect(fields).toHaveLength(2);
     expect(fields[0].value).toContain('<strong>');
-    expect(fields[1].value).toBe('<p>plain text</p>\n');
+    // Field 2 is not RichText → left untouched
+    expect(fields[1].value).toBe('plain text');
     expect(result).not.toHaveProperty('fields_format');
   });
 
+  it('leaves all custom_fields untouched when the RichText id set is empty', () => {
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'markdown',
+        custom_fields: [{ asset_layout_field_id: 1, value: '**bold**' }],
+      },
+      new Set(),
+    );
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].value).toBe('**bold**');
+    expect(result).not.toHaveProperty('fields_format');
+  });
+
+  it('matches asset_layout_field_id supplied as a string', () => {
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'markdown',
+        custom_fields: [{ asset_layout_field_id: '5', value: '# Title' }],
+      },
+      new Set([5]),
+    );
+
+    const fields = result.custom_fields as Record<string, unknown>[];
+    expect(fields[0].value).toContain('<h1');
+  });
+
   it('leaves custom_fields unchanged when fields_format is html, but strips the flag', () => {
-    const result = applyAssetFieldsFormat({
-      fields_format: 'html',
-      custom_fields: [{ asset_layout_field_id: '1', value: '<p>hi</p>' }],
-    });
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'html',
+        custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
+      },
+      new Set([1]),
+    );
 
     const fields = result.custom_fields as Record<string, unknown>[];
     expect(fields[0].value).toBe('<p>hi</p>');
@@ -30,44 +64,43 @@ describe('applyAssetFieldsFormat', () => {
   });
 
   it('leaves custom_fields unchanged when fields_format is absent, but strips the flag', () => {
-    const result = applyAssetFieldsFormat({
-      custom_fields: [{ asset_layout_field_id: '1', value: '<p>hi</p>' }],
-    });
+    const result = applyAssetFieldsFormat(
+      {
+        custom_fields: [{ asset_layout_field_id: 1, value: '<p>hi</p>' }],
+      },
+      new Set([1]),
+    );
 
     const fields = result.custom_fields as Record<string, unknown>[];
     expect(fields[0].value).toBe('<p>hi</p>');
     expect(result).not.toHaveProperty('fields_format');
   });
 
-  it('skips non-string values in custom_fields', () => {
-    const result = applyAssetFieldsFormat({
-      fields_format: 'markdown',
-      custom_fields: [
-        { asset_layout_field_id: '1', value: 42 },
-        { asset_layout_field_id: '2', value: null },
-      ],
-    });
+  it('skips non-string values on RichText fields', () => {
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'markdown',
+        custom_fields: [
+          { asset_layout_field_id: 1, value: 42 },
+          { asset_layout_field_id: 2, value: null },
+        ],
+      },
+      new Set([1, 2]),
+    );
 
     const fields = result.custom_fields as Record<string, unknown>[];
     expect(fields[0].value).toBe(42);
     expect(fields[1].value).toBeNull();
   });
 
-  it('does not convert the asset_layout_field_id key', () => {
-    const result = applyAssetFieldsFormat({
-      fields_format: 'markdown',
-      custom_fields: [{ asset_layout_field_id: '**1**', value: 'test' }],
-    });
-
-    const fields = result.custom_fields as Record<string, unknown>[];
-    expect(fields[0].asset_layout_field_id).toBe('**1**');
-  });
-
   it('returns params unchanged (minus fields_format) when custom_fields is absent', () => {
-    const result = applyAssetFieldsFormat({
-      fields_format: 'markdown',
-      name: 'Test Asset',
-    });
+    const result = applyAssetFieldsFormat(
+      {
+        fields_format: 'markdown',
+        name: 'Test Asset',
+      },
+      new Set([1]),
+    );
 
     expect(result).toEqual({ name: 'Test Asset' });
     expect(result).not.toHaveProperty('fields_format');

--- a/nodes/Hudu/ai-tools/schema-generator.ts
+++ b/nodes/Hudu/ai-tools/schema-generator.ts
@@ -748,6 +748,10 @@ export function getAssetsCreateSchema() {
       .array(z.record(z.string(), z.unknown()))
       .optional()
       .describe('Custom field values as array of objects with asset_layout_field_id (numeric) and value. Each object: { "asset_layout_field_id": <number>, "value": <value> }. Call hudu_asset_layouts with operation get and the layout ID to discover available field IDs.'),
+    fields_format: z
+      .enum(['html', 'markdown'])
+      .optional()
+      .describe("Format of custom field string values. 'markdown' converts them to HTML before saving. Default html."),
   });
 }
 
@@ -978,6 +982,10 @@ export function getAssetsUpdateSchema() {
       .array(z.record(z.string(), z.unknown()))
       .optional()
       .describe('Custom field values as array of objects with asset_layout_field_id (numeric) and value. Each object: { "asset_layout_field_id": <number>, "value": <value> }. Call hudu_asset_layouts with operation get and the layout ID to discover available field IDs.'),
+    fields_format: z
+      .enum(['html', 'markdown'])
+      .optional()
+      .describe("Format of custom field string values. 'markdown' converts them to HTML before saving. Default html."),
   });
 }
 

--- a/nodes/Hudu/ai-tools/schema-generator.ts
+++ b/nodes/Hudu/ai-tools/schema-generator.ts
@@ -751,7 +751,7 @@ export function getAssetsCreateSchema() {
     fields_format: z
       .enum(['html', 'markdown'])
       .optional()
-      .describe("Format of custom field string values. 'markdown' converts them to HTML before saving. Default html."),
+      .describe("Format of RichText custom field values. 'markdown' converts RichText fields to HTML before saving (other field types are left as-is). Default html."),
   });
 }
 
@@ -985,7 +985,7 @@ export function getAssetsUpdateSchema() {
     fields_format: z
       .enum(['html', 'markdown'])
       .optional()
-      .describe("Format of custom field string values. 'markdown' converts them to HTML before saving. Default html."),
+      .describe("Format of RichText custom field values. 'markdown' converts RichText fields to HTML before saving (other field types are left as-is). Default html."),
   });
 }
 

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -147,6 +147,24 @@ export function applyContentFormat(params: Record<string, unknown>): Record<stri
 }
 
 /**
+ * Strips the client-only fields_format flag and, when 'markdown', converts the
+ * 'value' key of custom_fields array items to HTML before they reach the Hudu API.
+ * Mirrors the regular node's fieldsFormat handling for asset RichText fields.
+ */
+export function applyAssetFieldsFormat(params: Record<string, unknown>): Record<string, unknown> {
+  const { fields_format, ...rest } = params;
+  if (fields_format === 'markdown' && Array.isArray(rest.custom_fields)) {
+    rest.custom_fields = (rest.custom_fields as Record<string, unknown>[]).map((field) => {
+      const entry: Record<string, unknown> = { ...field };
+      if (typeof entry.value === 'string') {
+        entry.value = convertMarkdownToHtml(entry.value);
+      }
+      return entry;
+    });
+  }
+  return rest;
+}
+/**
  * Apply the full read-side shaping pipeline to a single record:
  *   content/photos strip → procedures rename + per-task assignee block
  *   → public_photos slim → omitDefaults (uniform field set per resource).
@@ -566,11 +584,14 @@ export async function executeHuduAiTool(
 
       case 'create': {
         // Articles: resolve company_id from folder_id if absent, handle global flag
+        // Assets: apply fields_format conversion
         let createParams = params;
         if (resource === 'articles') {
           const { resolvedParams, errorJson } = await resolveArticleCreateContext(params, context);
           if (errorJson) return errorJson;
           createParams = applyContentFormat(resolvedParams);
+        } else if (resource === 'assets') {
+          createParams = applyAssetFieldsFormat(params);
         }
 
         // For company-endpoint resources (assets), strip company_id from body and
@@ -605,7 +626,7 @@ export async function executeHuduAiTool(
         // where it is used for endpoint routing. For all other resources, company_id
         // belongs in the request body as a regular API field.
         const { id, ...withoutId } = params;
-        const updateParams = resource === 'articles' ? applyContentFormat(withoutId) : withoutId;
+        const updateParams = resource === 'articles' ? applyContentFormat(withoutId) : resource === 'assets' ? applyAssetFieldsFormat(withoutId) : withoutId;
         const { endpoint: baseEndpoint, fields } = getWriteEndpointAndFields(
           updateParams,
           config.endpoint,

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -37,6 +37,10 @@ import { runGetIdByName, runMoveAsset, runGetByLayout, GET_ID_BY_NAME_SUPPORTED_
 import { paginatedPostFilter, type PaginatedPostFilterResult } from './pagination-helper';
 import { runHelp, HELP_ENABLED_RESOURCES } from './help-registry';
 import { convertMarkdownToHtml } from '../utils/markdown/markdownToHtml';
+import { normaliseFieldType } from '../utils/fieldTypeUtils';
+import { ASSET_LAYOUT_FIELD_TYPES } from '../utils/constants';
+import { getAssetWithMetadata } from '../utils/assetFieldUtils';
+import type { IAssetLayoutFieldEntity } from '../resources/asset_layout_fields/asset_layout_fields.types';
 
 const EXCLUDED_FILTER_FIELDS = new Set(['limit', 'resource', 'operation']);
 
@@ -147,16 +151,47 @@ export function applyContentFormat(params: Record<string, unknown>): Record<stri
 }
 
 /**
- * Strips the client-only fields_format flag and, when 'markdown', converts the
- * 'value' key of custom_fields array items to HTML before they reach the Hudu API.
- * Mirrors the regular node's fieldsFormat handling for asset RichText fields.
+ * Fetches an asset layout and returns the numeric IDs of its RichText fields.
+ * Used to restrict Markdown->HTML conversion to RichText custom fields only,
+ * mirroring the regular node's field-type check.
  */
-export function applyAssetFieldsFormat(params: Record<string, unknown>): Record<string, unknown> {
+async function getRichTextFieldIds(
+  context: IExecuteFunctions | ISupplyDataFunctions,
+  layoutId: number,
+): Promise<Set<number>> {
+  const ids = new Set<number>();
+  const layoutResponse = (await handleGetOperation.call(
+    context as unknown as IExecuteFunctions,
+    '/asset_layouts',
+    String(layoutId),
+  )) as IDataObject;
+  const layout = layoutResponse?.asset_layout as { fields?: IAssetLayoutFieldEntity[] } | undefined;
+  if (layout && Array.isArray(layout.fields)) {
+    for (const f of layout.fields) {
+      if (normaliseFieldType(f.field_type) === ASSET_LAYOUT_FIELD_TYPES.RICH_TEXT) {
+        ids.add(Number(f.id));
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Strips the client-only fields_format flag and, when 'markdown', converts the
+ * 'value' of custom_fields entries whose asset_layout_field_id is a RichText
+ * field to HTML before they reach the Hudu API. Non-RichText fields (Date, List,
+ * Text, ...) are left untouched to avoid corrupting them. Mirrors the regular
+ * node's fieldsFormat handling.
+ */
+export function applyAssetFieldsFormat(
+  params: Record<string, unknown>,
+  richTextFieldIds: Set<number>,
+): Record<string, unknown> {
   const { fields_format, ...rest } = params;
   if (fields_format === 'markdown' && Array.isArray(rest.custom_fields)) {
     rest.custom_fields = (rest.custom_fields as Record<string, unknown>[]).map((field) => {
       const entry: Record<string, unknown> = { ...field };
-      if (typeof entry.value === 'string') {
+      if (richTextFieldIds.has(Number(entry.asset_layout_field_id)) && typeof entry.value === 'string') {
         entry.value = convertMarkdownToHtml(entry.value);
       }
       return entry;
@@ -164,6 +199,7 @@ export function applyAssetFieldsFormat(params: Record<string, unknown>): Record<
   }
   return rest;
 }
+
 /**
  * Apply the full read-side shaping pipeline to a single record:
  *   content/photos strip → procedures rename + per-task assignee block
@@ -591,7 +627,16 @@ export async function executeHuduAiTool(
           if (errorJson) return errorJson;
           createParams = applyContentFormat(resolvedParams);
         } else if (resource === 'assets') {
-          createParams = applyAssetFieldsFormat(params);
+          let richTextFieldIds = new Set<number>();
+          if (
+            params.fields_format === 'markdown' &&
+            Array.isArray(params.custom_fields) &&
+            params.custom_fields.length > 0 &&
+            params.asset_layout_id != null
+          ) {
+            richTextFieldIds = await getRichTextFieldIds(context, Number(params.asset_layout_id));
+          }
+          createParams = applyAssetFieldsFormat(params, richTextFieldIds);
         }
 
         // For company-endpoint resources (assets), strip company_id from body and
@@ -626,7 +671,27 @@ export async function executeHuduAiTool(
         // where it is used for endpoint routing. For all other resources, company_id
         // belongs in the request body as a regular API field.
         const { id, ...withoutId } = params;
-        const updateParams = resource === 'articles' ? applyContentFormat(withoutId) : resource === 'assets' ? applyAssetFieldsFormat(withoutId) : withoutId;
+        let updateParams: Record<string, unknown>;
+        if (resource === 'articles') {
+          updateParams = applyContentFormat(withoutId);
+        } else if (resource === 'assets') {
+          let richTextFieldIds = new Set<number>();
+          if (
+            withoutId.fields_format === 'markdown' &&
+            Array.isArray(withoutId.custom_fields) &&
+            withoutId.custom_fields.length > 0
+          ) {
+            const meta = await getAssetWithMetadata(
+              context as unknown as IExecuteFunctions,
+              Number(id),
+              0,
+            );
+            richTextFieldIds = await getRichTextFieldIds(context, meta.assetLayoutId);
+          }
+          updateParams = applyAssetFieldsFormat(withoutId, richTextFieldIds);
+        } else {
+          updateParams = withoutId;
+        }
         const { endpoint: baseEndpoint, fields } = getWriteEndpointAndFields(
           updateParams,
           config.endpoint,

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -39,9 +39,8 @@ import { runHelp, HELP_ENABLED_RESOURCES } from './help-registry';
 import { convertMarkdownToHtml } from '../utils/markdown/markdownToHtml';
 import { normaliseFieldType } from '../utils/fieldTypeUtils';
 import { ASSET_LAYOUT_FIELD_TYPES } from '../utils/constants';
-import { getAssetWithMetadata } from '../utils/assetFieldUtils';
+import { getAssetWithMetadata, toSnakeCaseFieldLabel } from '../utils/assetFieldUtils';
 import type { IAssetLayoutFieldEntity } from '../resources/asset_layout_fields/asset_layout_fields.types';
-import { toSnakeCase } from '../utils/formatters';
 
 const EXCLUDED_FILTER_FIELDS = new Set(['limit', 'resource', 'operation']);
 
@@ -175,7 +174,7 @@ async function getRichTextFieldKeys(
         keys.add(String(f.id));
         if (f.label) {
           keys.add(f.label);
-          keys.add(toSnakeCase(f.label));
+          keys.add(toSnakeCaseFieldLabel(f.label));
         }
       }
     }

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -41,6 +41,7 @@ import { normaliseFieldType } from '../utils/fieldTypeUtils';
 import { ASSET_LAYOUT_FIELD_TYPES } from '../utils/constants';
 import { getAssetWithMetadata } from '../utils/assetFieldUtils';
 import type { IAssetLayoutFieldEntity } from '../resources/asset_layout_fields/asset_layout_fields.types';
+import { toSnakeCase } from '../utils/formatters';
 
 const EXCLUDED_FILTER_FIELDS = new Set(['limit', 'resource', 'operation']);
 
@@ -151,15 +152,17 @@ export function applyContentFormat(params: Record<string, unknown>): Record<stri
 }
 
 /**
- * Fetches an asset layout and returns the numeric IDs of its RichText fields.
- * Used to restrict Markdown->HTML conversion to RichText custom fields only,
- * mirroring the regular node's field-type check.
+ * Fetches an asset layout and returns the set of identifiers by which a
+ * RichText field may be referenced in a custom_fields entry: its numeric id
+ * (as a string), its raw label, and its snake_case label. Used to restrict
+ * Markdown->HTML conversion to RichText fields only, mirroring the regular
+ * node's field-type check.
  */
-async function getRichTextFieldIds(
+async function getRichTextFieldKeys(
   context: IExecuteFunctions | ISupplyDataFunctions,
   layoutId: number,
-): Promise<Set<number>> {
-  const ids = new Set<number>();
+): Promise<Set<string>> {
+  const keys = new Set<string>();
   const layoutResponse = (await handleGetOperation.call(
     context as unknown as IExecuteFunctions,
     '/asset_layouts',
@@ -169,30 +172,47 @@ async function getRichTextFieldIds(
   if (layout && Array.isArray(layout.fields)) {
     for (const f of layout.fields) {
       if (normaliseFieldType(f.field_type) === ASSET_LAYOUT_FIELD_TYPES.RICH_TEXT) {
-        ids.add(Number(f.id));
+        keys.add(String(f.id));
+        if (f.label) {
+          keys.add(f.label);
+          keys.add(toSnakeCase(f.label));
+        }
       }
     }
   }
-  return ids;
+  return keys;
 }
 
 /**
- * Strips the client-only fields_format flag and, when 'markdown', converts the
- * 'value' of custom_fields entries whose asset_layout_field_id is a RichText
- * field to HTML before they reach the Hudu API. Non-RichText fields (Date, List,
- * Text, ...) are left untouched to avoid corrupting them. Mirrors the regular
- * node's fieldsFormat handling.
+ * Strips the client-only fields_format flag and, when 'markdown', converts
+ * RichText custom-field values from Markdown to HTML before they reach the Hudu
+ * API. Handles both accepted custom_fields shapes:
+ *   - { asset_layout_field_id, value } — convert value when the id is RichText.
+ *   - { <label|snake_case label>: content } — convert each string whose key
+ *     resolves to a RichText field.
+ * Non-RichText fields (Date, List, Text, ...) are left untouched. RichText
+ * fields are identified via `richTextKeys` (id / label / snake_case label).
  */
 export function applyAssetFieldsFormat(
   params: Record<string, unknown>,
-  richTextFieldIds: Set<number>,
+  richTextKeys: Set<string>,
 ): Record<string, unknown> {
   const { fields_format, ...rest } = params;
   if (fields_format === 'markdown' && Array.isArray(rest.custom_fields)) {
     rest.custom_fields = (rest.custom_fields as Record<string, unknown>[]).map((field) => {
       const entry: Record<string, unknown> = { ...field };
-      if (richTextFieldIds.has(Number(entry.asset_layout_field_id)) && typeof entry.value === 'string') {
-        entry.value = convertMarkdownToHtml(entry.value);
+      if ('asset_layout_field_id' in entry) {
+        // Explicit { asset_layout_field_id, value } shape.
+        if (richTextKeys.has(String(entry.asset_layout_field_id)) && typeof entry.value === 'string') {
+          entry.value = convertMarkdownToHtml(entry.value);
+        }
+      } else {
+        // Label/snake_case-keyed shape emitted by the regular node.
+        for (const [key, val] of Object.entries(entry)) {
+          if (richTextKeys.has(key) && typeof val === 'string') {
+            entry[key] = convertMarkdownToHtml(val);
+          }
+        }
       }
       return entry;
     });
@@ -627,16 +647,16 @@ export async function executeHuduAiTool(
           if (errorJson) return errorJson;
           createParams = applyContentFormat(resolvedParams);
         } else if (resource === 'assets') {
-          let richTextFieldIds = new Set<number>();
+          let richTextKeys = new Set<string>();
           if (
             params.fields_format === 'markdown' &&
             Array.isArray(params.custom_fields) &&
             params.custom_fields.length > 0 &&
             params.asset_layout_id != null
           ) {
-            richTextFieldIds = await getRichTextFieldIds(context, Number(params.asset_layout_id));
+            richTextKeys = await getRichTextFieldKeys(context, Number(params.asset_layout_id));
           }
-          createParams = applyAssetFieldsFormat(params, richTextFieldIds);
+          createParams = applyAssetFieldsFormat(params, richTextKeys);
         }
 
         // For company-endpoint resources (assets), strip company_id from body and
@@ -675,7 +695,7 @@ export async function executeHuduAiTool(
         if (resource === 'articles') {
           updateParams = applyContentFormat(withoutId);
         } else if (resource === 'assets') {
-          let richTextFieldIds = new Set<number>();
+          let richTextKeys = new Set<string>();
           if (
             withoutId.fields_format === 'markdown' &&
             Array.isArray(withoutId.custom_fields) &&
@@ -686,9 +706,9 @@ export async function executeHuduAiTool(
               Number(id),
               0,
             );
-            richTextFieldIds = await getRichTextFieldIds(context, meta.assetLayoutId);
+            richTextKeys = await getRichTextFieldKeys(context, meta.assetLayoutId);
           }
-          updateParams = applyAssetFieldsFormat(withoutId, richTextFieldIds);
+          updateParams = applyAssetFieldsFormat(withoutId, richTextKeys);
         } else {
           updateParams = withoutId;
         }

--- a/nodes/Hudu/ai-tools/tool-executor.ts
+++ b/nodes/Hudu/ai-tools/tool-executor.ts
@@ -151,71 +151,89 @@ export function applyContentFormat(params: Record<string, unknown>): Record<stri
 }
 
 /**
- * Fetches an asset layout and returns the set of identifiers by which a
- * RichText field may be referenced in a custom_fields entry: its numeric id
- * (as a string), its raw label, and its snake_case label. Used to restrict
- * Markdown->HTML conversion to RichText fields only, mirroring the regular
- * node's field-type check.
+ * Fetches an asset layout and returns its field definitions (or an empty array
+ * when the layout cannot be read). Used to identify RichText fields and to map
+ * numeric field IDs to the snake_case label keys the Hudu API expects.
  */
-async function getRichTextFieldKeys(
+async function getAssetLayoutFields(
   context: IExecuteFunctions | ISupplyDataFunctions,
   layoutId: number,
-): Promise<Set<string>> {
-  const keys = new Set<string>();
+): Promise<IAssetLayoutFieldEntity[]> {
   const layoutResponse = (await handleGetOperation.call(
     context as unknown as IExecuteFunctions,
     '/asset_layouts',
     String(layoutId),
   )) as IDataObject;
   const layout = layoutResponse?.asset_layout as { fields?: IAssetLayoutFieldEntity[] } | undefined;
-  if (layout && Array.isArray(layout.fields)) {
-    for (const f of layout.fields) {
-      if (normaliseFieldType(f.field_type) === ASSET_LAYOUT_FIELD_TYPES.RICH_TEXT) {
-        keys.add(String(f.id));
-        if (f.label) {
-          keys.add(f.label);
-          keys.add(toSnakeCaseFieldLabel(f.label));
-        }
-      }
-    }
-  }
-  return keys;
+  return layout && Array.isArray(layout.fields) ? layout.fields : [];
 }
 
 /**
- * Strips the client-only fields_format flag and, when 'markdown', converts
- * RichText custom-field values from Markdown to HTML before they reach the Hudu
- * API. Handles both accepted custom_fields shapes:
- *   - { asset_layout_field_id, value } — convert value when the id is RichText.
- *   - { <label|snake_case label>: content } — convert each string whose key
- *     resolves to a RichText field.
- * Non-RichText fields (Date, List, Text, ...) are left untouched. RichText
- * fields are identified via `richTextKeys` (id / label / snake_case label).
+ * Strips the client-only fields_format flag and normalises asset custom_fields
+ * for the Hudu API, which expects label/snake_case-keyed objects (e.g.
+ * { serial_number: '...' }), as the regular node emits.
+ *
+ * Two input shapes are accepted:
+ *   - { asset_layout_field_id, value } — rewritten to { <snake_label>: value }
+ *     using the layout; the value is converted from Markdown to HTML when the
+ *     field is RichText and fields_format is 'markdown'.
+ *   - { <label|snake_case label>: content } — already Hudu-shaped; each string
+ *     whose key resolves to a RichText field is converted when markdown.
+ *
+ * Non-RichText values are never converted. Entries whose asset_layout_field_id
+ * is unknown to the layout are left untouched.
  */
 export function applyAssetFieldsFormat(
   params: Record<string, unknown>,
-  richTextKeys: Set<string>,
+  layoutFields: IAssetLayoutFieldEntity[],
 ): Record<string, unknown> {
   const { fields_format, ...rest } = params;
-  if (fields_format === 'markdown' && Array.isArray(rest.custom_fields)) {
-    rest.custom_fields = (rest.custom_fields as Record<string, unknown>[]).map((field) => {
-      const entry: Record<string, unknown> = { ...field };
-      if ('asset_layout_field_id' in entry) {
-        // Explicit { asset_layout_field_id, value } shape.
-        if (richTextKeys.has(String(entry.asset_layout_field_id)) && typeof entry.value === 'string') {
-          entry.value = convertMarkdownToHtml(entry.value);
-        }
-      } else {
-        // Label/snake_case-keyed shape emitted by the regular node.
-        for (const [key, val] of Object.entries(entry)) {
-          if (richTextKeys.has(key) && typeof val === 'string') {
-            entry[key] = convertMarkdownToHtml(val);
-          }
+  if (!Array.isArray(rest.custom_fields)) {
+    return rest;
+  }
+
+  const isMarkdown = fields_format === 'markdown';
+  const snakeLabelById = new Map<string, string>();
+  const richTextKeys = new Set<string>();
+  for (const f of layoutFields) {
+    const snakeLabel = f.label ? toSnakeCaseFieldLabel(f.label) : '';
+    snakeLabelById.set(String(f.id), snakeLabel);
+    if (normaliseFieldType(f.field_type) === ASSET_LAYOUT_FIELD_TYPES.RICH_TEXT) {
+      richTextKeys.add(String(f.id));
+      if (f.label) {
+        richTextKeys.add(f.label);
+        richTextKeys.add(snakeLabel);
+      }
+    }
+  }
+
+  rest.custom_fields = (rest.custom_fields as Record<string, unknown>[]).map((field) => {
+    if ('asset_layout_field_id' in field) {
+      // Rewrite { asset_layout_field_id, value } to Hudu's { <snake_label>: value }.
+      const idKey = String(field.asset_layout_field_id);
+      const snakeLabel = snakeLabelById.get(idKey);
+      if (snakeLabel === undefined) {
+        return { ...field };
+      }
+      let value = field.value;
+      if (isMarkdown && richTextKeys.has(idKey) && typeof value === 'string') {
+        value = convertMarkdownToHtml(value);
+      }
+      return { [snakeLabel]: value };
+    }
+
+    // Label/snake_case-keyed shape emitted by the regular node — already Hudu-shaped.
+    const entry: Record<string, unknown> = { ...field };
+    if (isMarkdown) {
+      for (const [key, val] of Object.entries(entry)) {
+        if (richTextKeys.has(key) && typeof val === 'string') {
+          entry[key] = convertMarkdownToHtml(val);
         }
       }
-      return entry;
-    });
-  }
+    }
+    return entry;
+  });
+
   return rest;
 }
 
@@ -638,24 +656,24 @@ export async function executeHuduAiTool(
       }
 
       case 'create': {
-        // Articles: resolve company_id from folder_id if absent, handle global flag
-        // Assets: apply fields_format conversion
+        // Articles: resolve company_id from folder_id if absent, handle global flag.
+        // Assets: normalise custom_fields to Hudu's label-keyed shape and, when
+        // fields_format is 'markdown', convert RichText values to HTML.
         let createParams = params;
         if (resource === 'articles') {
           const { resolvedParams, errorJson } = await resolveArticleCreateContext(params, context);
           if (errorJson) return errorJson;
           createParams = applyContentFormat(resolvedParams);
         } else if (resource === 'assets') {
-          let richTextKeys = new Set<string>();
+          let layoutFields: IAssetLayoutFieldEntity[] = [];
           if (
-            params.fields_format === 'markdown' &&
             Array.isArray(params.custom_fields) &&
             params.custom_fields.length > 0 &&
             params.asset_layout_id != null
           ) {
-            richTextKeys = await getRichTextFieldKeys(context, Number(params.asset_layout_id));
+            layoutFields = await getAssetLayoutFields(context, Number(params.asset_layout_id));
           }
-          createParams = applyAssetFieldsFormat(params, richTextKeys);
+          createParams = applyAssetFieldsFormat(params, layoutFields);
         }
 
         // For company-endpoint resources (assets), strip company_id from body and
@@ -694,9 +712,8 @@ export async function executeHuduAiTool(
         if (resource === 'articles') {
           updateParams = applyContentFormat(withoutId);
         } else if (resource === 'assets') {
-          let richTextKeys = new Set<string>();
+          let layoutFields: IAssetLayoutFieldEntity[] = [];
           if (
-            withoutId.fields_format === 'markdown' &&
             Array.isArray(withoutId.custom_fields) &&
             withoutId.custom_fields.length > 0
           ) {
@@ -705,9 +722,9 @@ export async function executeHuduAiTool(
               Number(id),
               0,
             );
-            richTextKeys = await getRichTextFieldKeys(context, meta.assetLayoutId);
+            layoutFields = await getAssetLayoutFields(context, meta.assetLayoutId);
           }
-          updateParams = applyAssetFieldsFormat(withoutId, richTextKeys);
+          updateParams = applyAssetFieldsFormat(withoutId, layoutFields);
         } else {
           updateParams = withoutId;
         }

--- a/nodes/Hudu/descriptions/assets.description.ts
+++ b/nodes/Hudu/descriptions/assets.description.ts
@@ -238,6 +238,30 @@ export const assetsFields: INodeProperties[] = [
     description:
       'Map one or more asset fields to update, including name and other standard properties. You may update a single field or multiple fields in one operation.',
   },
+  {
+    displayName: 'Fields Format',
+    name: 'fieldsFormat',
+    type: 'options',
+    default: 'html',
+    options: [
+      {
+        name: 'HTML',
+        value: 'html',
+      },
+      {
+        name: 'Markdown',
+        value: 'markdown',
+      },
+    ],
+    displayOptions: {
+      show: {
+        resource: ['assets'],
+        operation: ['create', 'update'],
+      },
+    },
+    description:
+      'Whether RichText field values are HTML (sent as-is) or Markdown (converted to HTML before sending to Hudu)',
+  },
 
   // ----------------------------------
   //         assets:getAll

--- a/nodes/Hudu/resources/assets/assets.handler.ts
+++ b/nodes/Hudu/resources/assets/assets.handler.ts
@@ -18,20 +18,13 @@ import {
   validateFieldForMapping,
   transformFieldValueForUpdate,
   updateAssetWithMappedFields,
+  toSnakeCaseFieldLabel,
 } from '../../utils/assetFieldUtils';
 import type { IAssetLayoutFieldEntity } from '../asset_layout_fields/asset_layout_fields.types';
 import { isStandardField, normaliseFieldType } from '../../utils/fieldTypeUtils';
 import { parseHuduApiErrorWithContext } from '../../utils/errorParser';
 import { addAssetFieldMarkdown } from '../../utils/markdown/assetFields';
 import { convertMarkdownToHtml } from '../../utils/markdown/markdownToHtml';
-
-function toSnakeCaseFieldLabel(label: string): string {
-  return label
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
 
 /**
  * Converts Markdown field values to HTML for RichText layout fields

--- a/nodes/Hudu/resources/assets/assets.handler.ts
+++ b/nodes/Hudu/resources/assets/assets.handler.ts
@@ -63,6 +63,11 @@ function convertRichTextFields(
   }
 
   for (const [fieldKey, fieldValue] of Object.entries(mappedFields)) {
+    // Standard fields (e.g. name) route to the top-level body and must never be
+    // converted, even if a RichText custom field shares their label.
+    if (isStandardField(fieldKey)) {
+      continue;
+    }
     if (richTextKeys.has(fieldKey) && typeof fieldValue === 'string') {
       mappedFields[fieldKey] = convertMarkdownToHtml(fieldValue);
     }

--- a/nodes/Hudu/resources/assets/assets.handler.ts
+++ b/nodes/Hudu/resources/assets/assets.handler.ts
@@ -23,6 +23,7 @@ import type { IAssetLayoutFieldEntity } from '../asset_layout_fields/asset_layou
 import { isStandardField } from '../../utils/fieldTypeUtils';
 import { parseHuduApiErrorWithContext } from '../../utils/errorParser';
 import { addAssetFieldMarkdown } from '../../utils/markdown/assetFields';
+import { convertMarkdownToHtml } from '../../utils/markdown/markdownToHtml';
 
 function toSnakeCaseFieldLabel(label: string): string {
   return label
@@ -30,6 +31,34 @@ function toSnakeCaseFieldLabel(label: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Converts Markdown field values to HTML for RichText layout fields
+ * when fieldsFormat is 'markdown'. Mutates mappedFields in place.
+ */
+function convertRichTextFields(
+  mappedFields: IDataObject,
+  layoutFields: IAssetLayoutFieldEntity[],
+  fieldsFormat: string,
+) {
+  if (fieldsFormat !== 'markdown' || !Array.isArray(layoutFields)) {
+    return;
+  }
+
+  const richTextIds = layoutFields
+    .filter((f) => f.field_type === 'RichText')
+    .map((f) => String(f.id));
+
+  if (richTextIds.length === 0) {
+    return;
+  }
+
+  for (const [fieldId, fieldValue] of Object.entries(mappedFields)) {
+    if (richTextIds.includes(fieldId) && typeof fieldValue === 'string') {
+      mappedFields[fieldId] = convertMarkdownToHtml(fieldValue);
+    }
+  }
 }
 
 export async function handleAssetsOperation(
@@ -84,7 +113,11 @@ export async function handleAssetsOperation(
       if (!Array.isArray(layout.fields)) {
         throw new NodeOperationError(this.getNode(), `Asset layout with ID '${layoutId}' has no fields.`, { itemIndex: i });
       }
-      
+
+      // Convert Markdown to HTML for RichText fields if requested
+      const fieldsFormat = this.getNodeParameter('fieldsFormat', i, 'html') as string;
+      convertRichTextFields(mappedFields, layout.fields, fieldsFormat);
+
       // Process each mapped field
       for (const [fieldId, fieldValue] of Object.entries(mappedFields)) {
         if (isStandardField(fieldId)) {
@@ -359,7 +392,11 @@ export async function handleAssetsOperation(
         if (!Array.isArray(layout.fields)) {
           throw new NodeOperationError(this.getNode(), `Asset layout with ID '${assetMeta.assetLayoutId}' has no fields.`, { itemIndex: i });
         }
-        
+
+        // Convert Markdown to HTML for RichText fields if requested
+        const fieldsFormat = this.getNodeParameter('fieldsFormat', i, 'html') as string;
+        convertRichTextFields(mappedFields, layout.fields, fieldsFormat);
+
         const updatePayload: IDataObject = {};
         const customUpdateFields: IDataObject[] = [];
         

--- a/nodes/Hudu/resources/assets/assets.handler.ts
+++ b/nodes/Hudu/resources/assets/assets.handler.ts
@@ -11,7 +11,7 @@ import {
 import type { AssetsOperations } from './assets.types';
 import { NodeOperationError, NodeApiError } from 'n8n-workflow';
 import { debugLog } from '../../utils/debugConfig';
-import { HUDU_API_CONSTANTS } from '../../utils/constants';
+import { HUDU_API_CONSTANTS, ASSET_LAYOUT_FIELD_TYPES } from '../../utils/constants';
 import { getCompanyIdForAsset } from '../../utils/operations/getCompanyIdForAsset';
 import {
   getAssetWithMetadata,
@@ -20,7 +20,7 @@ import {
   updateAssetWithMappedFields,
 } from '../../utils/assetFieldUtils';
 import type { IAssetLayoutFieldEntity } from '../asset_layout_fields/asset_layout_fields.types';
-import { isStandardField } from '../../utils/fieldTypeUtils';
+import { isStandardField, normaliseFieldType } from '../../utils/fieldTypeUtils';
 import { parseHuduApiErrorWithContext } from '../../utils/errorParser';
 import { addAssetFieldMarkdown } from '../../utils/markdown/assetFields';
 import { convertMarkdownToHtml } from '../../utils/markdown/markdownToHtml';
@@ -46,17 +46,25 @@ function convertRichTextFields(
     return;
   }
 
-  const richTextIds = layoutFields
-    .filter((f) => f.field_type === 'RichText')
-    .map((f) => String(f.id));
+  // Field mappings may be keyed by numeric field ID or by field label
+  // (validateFieldForMapping accepts both), so collect both identifiers.
+  const richTextKeys = new Set<string>();
+  for (const f of layoutFields) {
+    if (normaliseFieldType(f.field_type) === ASSET_LAYOUT_FIELD_TYPES.RICH_TEXT) {
+      richTextKeys.add(String(f.id));
+      if (f.label) {
+        richTextKeys.add(f.label);
+      }
+    }
+  }
 
-  if (richTextIds.length === 0) {
+  if (richTextKeys.size === 0) {
     return;
   }
 
-  for (const [fieldId, fieldValue] of Object.entries(mappedFields)) {
-    if (richTextIds.includes(fieldId) && typeof fieldValue === 'string') {
-      mappedFields[fieldId] = convertMarkdownToHtml(fieldValue);
+  for (const [fieldKey, fieldValue] of Object.entries(mappedFields)) {
+    if (richTextKeys.has(fieldKey) && typeof fieldValue === 'string') {
+      mappedFields[fieldKey] = convertMarkdownToHtml(fieldValue);
     }
   }
 }

--- a/nodes/Hudu/utils/__tests__/toSnakeCaseFieldLabel.test.ts
+++ b/nodes/Hudu/utils/__tests__/toSnakeCaseFieldLabel.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { toSnakeCaseFieldLabel } from '../assetFieldUtils';
+
+describe('toSnakeCaseFieldLabel', () => {
+  it('lowercases and underscores multi-word labels', () => {
+    expect(toSnakeCaseFieldLabel('Serial Number')).toBe('serial_number');
+  });
+
+  it('keeps acronyms and digits together (does not split camel/Pascal case)', () => {
+    // Regular node builds Hudu keys this way; AI-tools lookups must match.
+    expect(toSnakeCaseFieldLabel('OAuth Token')).toBe('oauth_token');
+    expect(toSnakeCaseFieldLabel('IPv4 Notes')).toBe('ipv4_notes');
+  });
+
+  it('collapses runs of non-alphanumerics and trims edge underscores', () => {
+    expect(toSnakeCaseFieldLabel('  Notes / Comments!  ')).toBe('notes_comments');
+  });
+});

--- a/nodes/Hudu/utils/assetFieldUtils.ts
+++ b/nodes/Hudu/utils/assetFieldUtils.ts
@@ -13,6 +13,22 @@ import {
 import { ASSET_LAYOUT_FIELD_TYPES } from './constants';
 
 /**
+ * Normalises an asset layout field label into the snake_case key that the Hudu
+ * API expects in a custom_fields entry: lowercase, then every run of
+ * non-alphanumeric characters collapsed to a single underscore, with leading/
+ * trailing underscores trimmed (e.g. "OAuth Token" -> "oauth_token",
+ * "IPv4 Notes" -> "ipv4_notes"). This is the canonical key used when building
+ * the write payload, so any lookup against it must use the same transform.
+ */
+export function toSnakeCaseFieldLabel(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
  * Interface for asset metadata with fields and layout info
  */
 export interface AssetWithMetadata {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-hudu",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "This n8n custom node facilitates integration with Hudu's API.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Closes #37.

## What
Adds a **Fields Format: HTML | Markdown** option to Asset **create** and **update**. When set to `Markdown`, RichText custom-field values are converted to HTML via `marked` before being sent to Hudu.

## How
- **Regular node** (`assets.handler.ts`): `convertRichTextFields()` detects RichText fields from the asset layout (`field_type === 'RichText'`) and converts only those values. Guarded against a missing/non-array layout.
- **AI Tools** (`tool-executor.ts`): `applyAssetFieldsFormat()` converts the string `value` of each `custom_fields` entry when `fields_format` is `'markdown'`, and strips the client-only flag — mirroring the existing `applyContentFormat()` article handling.
- **Descriptions**: single consolidated `fieldsFormat` toggle shown for both `create` and `update`.
- **Schemas**: `fields_format` enum added to both asset create/update AI-tool schemas.

Default is `html` (values sent as-is), so existing workflows are unaffected.

## Tests
- New `applyAssetFieldsFormat.test.ts` (6 cases: markdown conversion, html passthrough, absent flag, non-string skip, `asset_layout_field_id` untouched, absent `custom_fields`).
- Full suite: **28/28 pass**. `tsc` clean. `npm run build` succeeds. Lint delta vs `main` = 0.

## Notes
- Bumps version to **2.9.0** and adds a CHANGELOG `### Added` entry, per repo convention. Revert those two lines if releases are gated separately.